### PR TITLE
hotfix/1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "eslint-config-pirika-install-deps-react": "bin/install-deps-react"
   },
   "peerDependencies": {
-    "eslint": "^8.6.0",
+    "eslint": ">= 6",
     "prettier": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "^5.9.1",
     "@typescript-eslint/parser": "^5.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-pirika",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "eslint / prettier config for Pirika projects",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
ESLintの参照バージョンを`"^8.6.0"`指定から`">= 6"`に下げました。
8.6.0以上だと、react-script が依存しているESLintのバージョンと競合し、`npm run build`が通らなくなりました。