### PR TITLE
インストールスクリプトにて、必要な依存ライブラリを追加

### DIFF
--- a/bin/install-deps
+++ b/bin/install-deps
@@ -5,6 +5,8 @@ const { exec } = require('child_process');
 exec(
   "\
     npm install --save-dev \
+    @typescript-eslint/eslint-plugin \
+    @typescript-eslint/parser \
     eslint-config-airbnb-base \
     eslint-config-prettier \
     eslint-plugin-prefer-arrow \

--- a/bin/install-deps
+++ b/bin/install-deps
@@ -3,7 +3,13 @@
 const { exec } = require('child_process');
 
 exec(
-  "npm install --save-dev eslint-config-airbnb-base",
+  "\
+    npm install --save-dev \
+    eslint-config-airbnb-base \
+    eslint-config-prettier \
+    eslint-plugin-prefer-arrow \
+    prettier \
+  ",
   (error, stdout, stderr) => {
     if (error) {
       console.error(`[ERROR] ${error}`);

--- a/bin/install-deps-react
+++ b/bin/install-deps-react
@@ -5,6 +5,8 @@ const { exec } = require('child_process');
 exec(
   "\
     npm install --save-dev \
+    @typescript-eslint/eslint-plugin \
+    @typescript-eslint/parser \
     eslint-config-airbnb \
     eslint-plugin-jsx-a11y \
     eslint-plugin-react \

--- a/bin/install-deps-react
+++ b/bin/install-deps-react
@@ -3,7 +3,16 @@
 const { exec } = require('child_process');
 
 exec(
-  "npm install --save-dev eslint-config-airbnb eslint-plugin-jsx-a11y eslint-plugin-react eslint-plugin-react-hooks",
+  "\
+    npm install --save-dev \
+    eslint-config-airbnb \
+    eslint-plugin-jsx-a11y \
+    eslint-plugin-react \
+    eslint-plugin-react-hooks \
+    eslint-config-prettier \
+    eslint-plugin-prefer-arrow \
+    prettier \
+  ",
   (error, stdout, stderr) => {
     if (error) {
       console.error(`[ERROR] ${error}`);


### PR DESCRIPTION
#6 

以下のライブラリがインストールスクリプトで入っていなかったので、インストール対象に加えました。

- eslint-config-prettier
- eslint-plugin-prefer-arrow
- prettier

なお、以下のライブラリはユーザ側でインストールされる想定として入れていません(が、このライブラリ側で全て対応するのであれば入れても良いかなと思っています)。

- @typescript-eslint/eslint-plugin
- @typescript-eslint/parser